### PR TITLE
manifest: tabs permission is actually unused

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,6 @@
     "background": {
         "scripts": ["background.js"]
     },
-    "permissions": [
-        "tabs"
-    ],
     "commands": {
         "new-tab": {
             "suggested_key": {


### PR DESCRIPTION
Notification from Google:

- Violation: “tabs” permissions are requested in manifest file but properties and methods related to the permission are not used in the code
- How to rectify: Remove the tabs permissions from the manifest file.
- Additional Information: Please note that tabs permission is required only when accessing title, url, pendingUrl and favIconUrl properties of tabs. For create() method tabs permission is not required. For more information please refer to the tabs documentation.